### PR TITLE
Don't automerge PRs when they have the label "no auto merge"

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,6 +13,10 @@ on:
   pull_request_review:
     types:
       - submitted
+  # TODO: status may be triggering automerge unexpectedly
+  #
+  # Automerge pipeline got started for a regular commit on master "on: status" even though
+  # status here is empty. Perhaps this is old syntax and just need to remove status.
   status: {}
 jobs:
   test:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -75,4 +75,4 @@ jobs:
         uses: "pascalgn/automerge-action@2c8e667a3386187418587517e5bfe33470d19b5b"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_LABELS: ""
+          MERGE_LABELS: "!no auto merge"


### PR DESCRIPTION
Previously all maintainer PRs would be merged automatically, with this PR now they will be automerged unless the "no auto merge" label is added. Closes #16.