### PR TITLE
Update template from Cookiecutter using Cruft

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
     "template": "https://github.com/whoopnip/cookiecutter-pypi-sphinx",
-    "commit": "71d4620dbeff47e540b040dbbedbf12d809838b9",
+    "commit": "2454221c62c24b120db48fc0db534ea734445838",
     "context": {
         "cookiecutter": {
             "package_name": "py_qs_example",

--- a/Pipfile.orig
+++ b/Pipfile.orig
@@ -1,0 +1,26 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+sphinx = "*"
+sphinx-autobuild = "*"
+sphinx-autodoc-typehints = "*"
+sphinxcontrib-fulltoc = "*"
+sphinx-paramlinks = "*"
+sphinx-rtd-theme = {editable = true,git = "https://github.com/readthedocs/sphinx_rtd_theme.git",ref = "ab7d388448258a24f8f4fa96dccb69d24f571736"}
+sphinx-gallery = "*"
+sphinx-copybutton = "*"
+sphinx-sitemap = "*"
+twine = "*"
+pytest = "*"
+pytest-cov = "*"
+mypy = "*"
+pypandoc = "*"
+cruft = "*"
+
+[requires]
+python_version = "3.7"

--- a/conf.py
+++ b/conf.py
@@ -110,7 +110,7 @@ PACKAGE_URLS = {
 
 # Does not affect anything about the current package. Simply used for tracking when this repo was created off
 # of the quickstart template, so it is easier to bring over new changes to the template.
-_TEMPLATE_VERSION_TUPLE = (0, 4, 0)
+_TEMPLATE_VERSION_TUPLE = (0, 5, 1)
 
 if __name__ == '__main__':
     # Store config as environment variables


### PR DESCRIPTION
Update template from Cookiecutter using Cruft.

Before merging, review the changes and adjust manually if necessary. Especially look for
new files ending with `.orig` being added as this signifies a merge conflict that
needs to be resolved.

- Updates coming from [cookiecutter-pypi-sphinx][1]

[1]: https://github.com/whoopnip/cookiecutter-pypi-sphinx